### PR TITLE
feat: Accept string in mime keyword argument for @dump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dumper"
 uuid = "8642fa86-e71c-4b93-8618-293c1d7e5bde"
 authors = ["Cursor Insight <info@cursorinsight.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Dumper.jl
+++ b/src/Dumper.jl
@@ -126,7 +126,7 @@ macro dump(variable::Symbol, arguments...)
         get(arguments, :path, string(variable))
     directory::CompileTime{String} =
         get(arguments, :directory, :($STATE().directory))
-    mime::CompileTime{String} =
+    mime::CompileTime{Union{MIME, String}} =
         get(arguments, :mime, :($STATE().mime))
     mode::CompileTime{String} =
         get(arguments, :mode, :($STATE().mode))
@@ -134,7 +134,7 @@ macro dump(variable::Symbol, arguments...)
     return quote
         if $STATE().enabled
             let _path = $isabsolute ? $path : joinpath($directory, $path)
-                $save(_path, $mime, $variable; $mode)
+                $save(_path, MIME($mime), $variable; $mode)
             end
         end
     end |> esc


### PR DESCRIPTION
Current version only accepts instances of MIME type, this change wraps the passed value in `MIME()`, thus accepting plain strings as well.

```
julia> @dump body mime=MIME("text/html")

julia> @dump body mime="text/html"
```