### PR TITLE
fix: Move state initialization into __init__

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dumper"
 uuid = "8642fa86-e71c-4b93-8618-293c1d7e5bde"
 authors = ["Cursor Insight <info@cursorinsight.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
The old solution used a global constant, which was set at compile time. Hence the date/timestamp in the default directory name didn't reflect the load time of the module but rather its compilation time, causing the dump files to be overwritten in every run.

The new solution replaces a function with a constant Ref, which is initialized at module load time.