### PR TITLE
fix: Do proper escaping to avoid precompilation bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dumper"
 uuid = "8642fa86-e71c-4b93-8618-293c1d7e5bde"
 authors = ["Cursor Insight <info@cursorinsight.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ using Dumper: enable!, disable!, @dump
         @dump x path="3.txt"
         @test !isfile("$directory/3.txt")
 
-        enable!("$directory/sub")
+        enable!(directory = "$directory/sub")
         @test isdir("$directory/sub")
 
         @dump x
@@ -73,7 +73,7 @@ end
     end
 
     mktempdir() do directory
-        enable!(directory)
+        enable!(; directory, isabsolute = false)
         @test isdir(directory)
 
         dump()
@@ -88,7 +88,7 @@ end
         @test isfile("$directory/x")
         @test readlines("$directory/x") != ["3"]
 
-        enable!("$directory/sub")
+        enable!("$directory/sub"; mode = "w")
         @test isdir("$directory/sub")
 
         dump()


### PR DESCRIPTION
Using global escaping and interpolation messed up the state reference lookup, and enabling the dumper didn't always have the desired effect, depending on how precompilation worked.

Also get rid of the reference, it isn't necessary as long as the `State` itself is mutable.